### PR TITLE
Make path to log adjustable via command line.

### DIFF
--- a/demos/copilot/scripts/main_syslog.c
+++ b/demos/copilot/scripts/main_syslog.c
@@ -9,7 +9,9 @@
 
 #include "elisa-v2.h"
 
+#ifndef LOG_PATH
 #define LOG_PATH "/var/log/syslog"
+#endif
 #define LIGHTS_ON_STRING  "lights: on"
 #define LIGHTS_OFF_STRING "lights: off"
 #define SWITCH_ON_STRING  "switch: on"


### PR DESCRIPTION
This commit modifies the C code so that the path to the syslog can be adjusted via a definition passed to the compiler on the command line. This will allow us to use a local file if the syslog is not available due to the user's limited permissions.