### PR TITLE
demo: Add Makefile to run benchmark, add benchmark using local file, system clock

### DIFF
--- a/demos/copilot/src/monitors/Auxiliary.hs
+++ b/demos/copilot/src/monitors/Auxiliary.hs
@@ -30,11 +30,21 @@ ago n s = replicate (fromIntegral n) False ++ s
 timeSinceLastTime :: Stream Bool -> Stream Int64
 timeSinceLastTime input = clock - lastTime input
 
+-- | Number of steps since the last time a stream was True.
+timeSinceLastTime' :: Stream Bool -> Stream Int64
+timeSinceLastTime' input = externalClock - lastTime' input
+
 -- | Last time that some input stream when from False to True.
 lastTime :: Stream Bool -> Stream Int64
 lastTime input = g
   where
     g = if input then clock else ([0] ++ g)
+
+-- | Last time that some input stream when from False to True.
+lastTime' :: Stream Bool -> Stream Int64
+lastTime' input = g
+  where
+    g = if input then externalClock else ([0] ++ g)
 
 -- | External clock, provided by the C program.
 externalClock :: Stream Int64

--- a/demos/copilot/src/monitors/Dockerfile
+++ b/demos/copilot/src/monitors/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
       qemu-system-arm \
       qemu-system-misc \
       qemu-system-x86 \
+      tmux \
       vim \
       wget \
       && \

--- a/demos/copilot/src/monitors/MainSyslogClock.hs
+++ b/demos/copilot/src/monitors/MainSyslogClock.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+-- | License: SPDX-License-Identifier: MIT
+import Auxiliary
+
+-- * System inputs
+
+-- | External input that indicates whether the lights are on.
+lightsOn :: Stream Bool
+lightsOn = extern "lights" Nothing
+
+-- | External input that indicates whether the lights are off.
+lightsOff :: Stream Bool
+lightsOff = not lightsOn
+
+-- | This is true any time the lights go from off to on.
+lightsTurnedOn :: Stream Bool
+lightsTurnedOn = risingEdge lightsOn
+
+-- | This is true any time the lights go from on to off.
+lightsTurnedOff :: Stream Bool
+lightsTurnedOff = risingEdge lightsOff
+
+-- | External input that indicates whether the switch is in the on position.
+switchOn :: Stream Bool
+switchOn = extern "lightSwitch" Nothing
+
+-- | External input that indicates whether the switch is in the off position.
+switchOff :: Stream Bool
+switchOff = not switchOn
+
+-- | This is true any time the switch goes from off to on.
+switchTurnedOn :: Stream Bool
+switchTurnedOn = risingEdge switchOn
+
+-- | This is true any time the switch goes from on to off.
+switchTurnedOff :: Stream Bool
+switchTurnedOff = risingEdge switchOff
+
+-- * System Requirements
+
+-- | SR1: The Cabin Lights system shall turn lights on in less than 500 ms of
+--        the light switch turning on.
+--
+-- EC: the light switch turns on and, for 500 ms, the lights remain off.
+--
+-- EC (refined): If the lights are off, the switch was turned on 500 ms ago
+-- and the lights have been off for more than that time.
+monitor1 :: Stream Bool
+monitor1 = lightsOff
+        && timeSinceLastTime' switchTurnedOn > limit
+        && timeSinceLastTime' lightsTurnedOn > limit
+
+-- | SR2: The Cabin Lights system shall turn lights off in less than 500 ms of
+--        the light switch turning off.
+--
+-- EC: the light switch turns off and, for 500 ms, the lights remain on.
+monitor2 :: Stream Bool
+monitor2 = lightsOn
+        && timeSinceLastTime' switchTurnedOff > limit
+        && timeSinceLastTime' lightsTurnedOff > limit
+
+-- | Constant limit: amount of steps betwen the light switch turning on and
+-- the light turning on.
+limit :: Stream Int64
+limit = 500
+
+-- * Specification
+
+-- | Main specification to check
+spec :: Spec
+spec = do
+  -- Call the function violation1 with no args whenever monitor1 becomes true.
+  trigger "violation1" monitor1 []
+
+  -- Call the function violation2 with no args whenever monitor2 becomes true.
+  trigger "violation2" monitor2 []
+
+-- * Main program
+
+-- | Main Copilot entry.
+main :: IO ()
+main =
+  -- Copilot supports multiple actions, including running an interpreter to
+  -- debug specs, and running formal analysis to prove properties about a
+  -- system. In this case, we only care about compiling to C.
+  compileToC "elisa-time" spec

--- a/demos/copilot/src/monitors/Makefile
+++ b/demos/copilot/src/monitors/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: default clean prep run
 
-default: main_syslog main_syslog_local
+default: main_syslog main_syslog_local main_syslog_time
 
 prep:
 	cabal update
@@ -11,14 +11,20 @@ prep:
 elisa-v2.c elisa-v2.h elisa-v2_types.h: Main.hs Auxiliary.hs
 	runhaskell Main.hs
 
+elisa-time.c elisa-time.h elisa-time_types.h: MainSyslogClock.hs Auxiliary.hs
+	runhaskell MainSyslogClock.hs
+
 main_syslog: main_syslog.c elisa-v2.c elisa-v2.h elisa-v2_types.h
 	gcc main_syslog.c elisa-v2.c -o $@
 
 main_syslog_local: main_syslog.c elisa-v2.c elisa-v2.h elisa-v2_types.h
 	gcc -DLOG_PATH='"log_file"' -DNOTAIL main_syslog.c elisa-v2.c -o $@
 
+main_syslog_time: main_syslog_time.c elisa-time.c elisa-time.h elisa-time_types.h
+	gcc -DLOG_PATH='"syslog_file"' -DNOTAIL main_syslog_time.c elisa-time.c -o $@
+
 clean:
-	rm -f main_syslog main_syslog_local elisa-v2.c elisa-v2.h elisa-v2_types.h
+	rm -f main_syslog main_syslog_local elisa-v2.c elisa-v2.h elisa-v2_types.h elisa-time.*
 
 run: main_syslog_local
 	# Start a new tmux session

--- a/demos/copilot/src/monitors/Makefile
+++ b/demos/copilot/src/monitors/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: default clean prep
 
-default: main_syslog
+default: main_syslog main_syslog_local
 
 prep:
 	cabal update
@@ -14,5 +14,8 @@ elisa-v2.c elisa-v2.h elisa-v2_types.h: Main.hs Auxiliary.hs
 main_syslog: main_syslog.c elisa-v2.c elisa-v2.h elisa-v2_types.h
 	gcc main_syslog.c elisa-v2.c -o $@
 
+main_syslog_local: main_syslog.c elisa-v2.c elisa-v2.h elisa-v2_types.h
+	gcc -DLOG_PATH='"log_file"' -DNOTAIL main_syslog.c elisa-v2.c -o $@
+
 clean:
-	rm -f main_syslog elisa-v2.c elisa-v2.h elisa-v2_types.h
+	rm -f main_syslog main_syslog_local elisa-v2.c elisa-v2.h elisa-v2_types.h

--- a/demos/copilot/src/monitors/Makefile
+++ b/demos/copilot/src/monitors/Makefile
@@ -1,0 +1,18 @@
+# License: SPDX-License-Identifier: MIT
+
+.PHONY: default clean prep
+
+default: main_syslog
+
+prep:
+	cabal update
+	cabal v2-install --lib copilot copilot-core copilot-c99 copilot-language copilot-theorem copilot-libraries copilot-interpreter copilot-prettyprinter
+
+elisa-v2.c elisa-v2.h elisa-v2_types.h: Main.hs Auxiliary.hs
+	runhaskell Main.hs
+
+main_syslog: main_syslog.c elisa-v2.c elisa-v2.h elisa-v2_types.h
+	gcc main_syslog.c elisa-v2.c -o $@
+
+clean:
+	rm -f main_syslog elisa-v2.c elisa-v2.h elisa-v2_types.h

--- a/demos/copilot/src/monitors/Makefile
+++ b/demos/copilot/src/monitors/Makefile
@@ -1,6 +1,6 @@
 # License: SPDX-License-Identifier: MIT
 
-.PHONY: default clean prep
+.PHONY: default clean prep run
 
 default: main_syslog main_syslog_local
 
@@ -19,3 +19,17 @@ main_syslog_local: main_syslog.c elisa-v2.c elisa-v2.h elisa-v2_types.h
 
 clean:
 	rm -f main_syslog main_syslog_local elisa-v2.c elisa-v2.h elisa-v2_types.h
+
+run: main_syslog_local
+	# Start a new tmux session
+	tmux new-session -d -s my_session
+
+	# Split the window into 3 panes
+	tmux split-window -h
+	tmux split-window -v
+
+	# Run commands in each pane
+	tmux send-keys -t my_session:0.0 "bash -i <<< './main_syslog_local ; exec </dev/tty'" C-m
+
+	# Attach to the tmux session
+	tmux attach-session -t my_session

--- a/demos/copilot/src/monitors/main_syslog.c
+++ b/demos/copilot/src/monitors/main_syslog.c
@@ -49,7 +49,9 @@ int main() {
         perror("Error opening log file");
         exit(EXIT_FAILURE);
     }
+#ifndef NOTAIL
     fseek(file, 0, SEEK_END);
+#endif
 
     // Open the syslog for publishing notifications
     openlog("Copilot", LOG_PID | LOG_CONS, LOG_USER);
@@ -66,9 +68,11 @@ int main() {
                lightSwitch = true;
             if (strstr(text, SWITCH_OFF_STRING) != NULL)
                lightSwitch = false;
+#ifndef NOTAIL
         } else {
           sleep (1);
           clearerr(file);
+#endif
         }
 
         // Re-evaluate the monitors

--- a/demos/copilot/src/monitors/main_syslog.c
+++ b/demos/copilot/src/monitors/main_syslog.c
@@ -29,6 +29,7 @@ bool lightSwitch = false;
 void violation1 () {
   syslog(LOG_ERR, "Monitor violation: light switch didn't turn on on time.");
   printf("Monitor violation: light switch didn't turn on on time.\n");
+  exit(1);
 }
 
 /*
@@ -37,6 +38,7 @@ void violation1 () {
 void violation2 () {
   syslog(LOG_ERR, "Monitor violation: light switch didn't turn off on time.");
   printf("Monitor violation: light switch didn't turn off on time.\n");
+  exit(1);
 }
 
 // Main function

--- a/demos/copilot/src/monitors/main_syslog_time.c
+++ b/demos/copilot/src/monitors/main_syslog_time.c
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+/*
+ * This file implements a main driver for the test of the light switch
+ * and the lights turning on within a certain time.
+ *
+ * Limitations: This driver assumes that time is mononotic.
+ * If an event is read from a file that corresponds to a past time, the time of
+ * the event is adjusted (overwritten) so that it is assumed to have occurred
+ * at a strictly later time.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <syslog.h>
+#include <sys/time.h>
+
+#include "elisa-time.h"
+
+#ifndef LOG_PATH
+#define LOG_PATH "/var/log/syslog"
+#endif
+#define LIGHTS_ON_STRING  "lights: on"
+#define LIGHTS_OFF_STRING "lights: off"
+#define SWITCH_ON_STRING  "switch: on"
+#define SWITCH_OFF_STRING "switch: off"
+
+/*
+ * Minimum time delta between events.
+ */
+const int64_t MIN_DELTA = 1;
+
+/*
+ * Clock used by the monitors.
+ */
+int64_t external_clock = 0;
+
+/*
+ * Globals needed by the monitors to know the status of the system.
+ */
+bool lights      = false;
+bool lightSwitch = false;
+
+/*
+ * Fault handler: the light switch didn't turn on or took too long.
+ */
+void violation1 () {
+  syslog(LOG_ERR, "Monitor violation: light switch didn't turn on on time.");
+  printf("Monitor violation: light switch didn't turn on on time.\n");
+  exit(1);
+}
+
+/*
+ * Fault handler: the light switch didn't turn off or took too long.
+ */
+void violation2 () {
+  syslog(LOG_ERR, "Monitor violation: light switch didn't turn off on time.");
+  printf("Monitor violation: light switch didn't turn off on time.\n");
+  exit(1);
+}
+
+/*
+ * Update the internal clock to a new time.
+ *
+ * This function ensures that the clock is monotonic.
+ */
+void update_time(int64_t new_time) {
+  if (new_time > external_clock) {
+    external_clock = new_time;
+  } else {
+    external_clock += MIN_DELTA;
+  }
+}
+
+// Main function
+int main() {
+    // Used if we need to get the system clock;
+    struct timeval tv;
+    int64_t milliseconds;
+
+    // Open the syslog for reading and move to the end
+    FILE *file = fopen(LOG_PATH, "r");
+    if (!file) {
+        perror("Error opening log file");
+        exit(EXIT_FAILURE);
+    }
+#ifndef NOTAIL
+    fseek(file, 0, SEEK_END);
+#endif
+
+    // Open the syslog for publishing notifications
+    openlog("Copilot", LOG_PID | LOG_CONS, LOG_USER);
+
+    // Process each packet received and re-run the monitors.
+    char text[1024];
+    double lineTime;
+    while (1) {
+        if (fgets(text, sizeof(text), file)) {
+            if (strstr(text, LIGHTS_ON_STRING) != NULL)
+               lights = true;
+            if (strstr(text, LIGHTS_OFF_STRING) != NULL)
+               lights = false;
+            if (strstr(text, SWITCH_ON_STRING) != NULL)
+               lightSwitch = true;
+            if (strstr(text, SWITCH_OFF_STRING) != NULL)
+               lightSwitch = false;
+            if (sscanf(text, "[%lf]", &lineTime) == 1) {
+               update_time((int64_t)(lineTime));
+            } else {
+               gettimeofday(&tv, NULL);
+               milliseconds = (int64_t)(tv.tv_sec) * 1000 +
+                              (int64_t)(tv.tv_usec) / 1000;
+               update_time(milliseconds);
+            }
+#ifndef NOTAIL
+        } else {
+          sleep (1);
+          clearerr(file);
+#endif
+        }
+
+        // Re-evaluate the monitors
+        step();
+    }
+
+    // Close the syslog for reading and writing. Presumably, this is never
+    // reached.
+    closelog();
+    fclose(file);
+    return 0;
+}


### PR DESCRIPTION
Add a makefile that compiles all test files and runs the benchmark.

NOTE: This is currently WIP and only compiles Copilot. We'll add any other pieces of code (e.g., python scripts), as well as the run target.