### PR TITLE
Copilot: use container for backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
 .DS_Store
+elisa-v2.c
+elisa-time.c
+elisa-v2.h
+elisa-v2_types.h
+elisa-time.h
+elisa-time_types.h
+log_file
+main_syslog
+main_syslog_local
+main_syslog_time
+*.pyc
+syslog_file
+log_file
+*.swp

--- a/demos/copilot/BasicDemo.md
+++ b/demos/copilot/BasicDemo.md
@@ -3,41 +3,42 @@
 
 ## Build
 
-Clone use case codebase
+Assuming the code base was previously cloned during [Environment Setup](../copilot/EnvSetup.md) as follows.
 
 ```
 git clone https://github.com/elisa-tech/wg-aerospace.git
 ```
 
-Build Copilot compile monitor
+Build the demo
 
 ```
-cd wg-aerospace/demos/copilot
-... do work....
+cd wg-aerospace/demos/copilot/src/monitors
+make prep  # Retrieves the container with tooling
+make       # Runs Haskell & Builds demo applications
 ```
 
 ## Launch
 
-Logical steps
-- Basic setup, run example
+```
+make run
+```
+
+- This will open a window in a TMUX environment with 3 sub-windows:
+  - The monitoring application
+  - The light server application
+  - The switch application
+- In the latter, the command to run is already prepared as:
+  - `python3 ../python/switch.py`
+  - ....which can be run to start the demo
+- To exit the TMUX environment:
+  - Press `CTRL+b`
+  - type `:kill-session` <Enter>
+
+
+## Future improvements
+
+- How to extend / using it for your own cases.
 - Example modifying app behavior (run for consistent results)
 - Tailor copilot spec (run for consistent results)
 - Modify system to prove spec/monitor tailoring captures intended behavior
-
-Launch sequence (raw frames)
-  1) Start copilot log and Ethernet monitor (bound to localhost)
-  2) Bind light app to localhost
-  3) Bind light server to localhost
-  4) Run client with arg to change state (run x3 to cycle through all transitions - on off on)
-
-```
-call sequence....
-```
-
-## Observations
-
-How to extend / using it for your own cases.
-
-Do we want to draw a mermaid diagram and have copilot auto gen the monitor?
-
-?
+- Extend the docs - Do we want to draw a mermaid diagram and have copilot auto gen the monitor?

--- a/demos/copilot/EnvSetup.md
+++ b/demos/copilot/EnvSetup.md
@@ -25,27 +25,7 @@ Next, in the shell started above
 - Clone use case codebase `git clone https://github.com/elisa-tech/wg-aerospace.git` and `cd wg-aerospace`.
 - Navigate to `./demos/env`, run our [environment setup script](../env/setup-env.sh) as a normal user with sudoers rights `./setup-env.sh`. If this script failed with a "Sudo is disabled on that computer" error.  For Windows 11 WSL, to enable Sudo, navigate to Settings > System > For Developers and toggle on the Enable sudo option.
 
-The last step is to switch to the specific demo folder and follow the instructions following these commands in a shell:
-- `cd demos/copilot/src/monitors`
-- `make prep`
-- `cabal update`
-  - Which downloads the latest package list from hackage.haskell.org and should result in:
-  - "Package list of hackage.haskell.org has been updated."
-- `cabal v2-install --lib copilot copilot-core copilot-c99 copilot-language copilot-theorem copilot-libraries copilot-interpreter copilot-prettyprinter`
-  - Which should result in:
-  - "Up to date"
-- `make`
-- `make run`
-- This will open a window in a TMUX environment with 3 sub-windows:
-  - The monitoring application
-  - The light server application
-  - The switch application
-- In the latter, the command to run is already prepared as:
-  - `python3 ../python/switch.py`
-  - ....which can be run to start the demo
-- To exit the TMUX environment:
-  - Press `CTRL+B`
-  - type `kill-session`
+The last step is to try out the [Basic Demo](../copilot/BasicDemo.md) using this new environment.
 
 ## References
 

--- a/demos/copilot/src/monitors/.gitignore
+++ b/demos/copilot/src/monitors/.gitignore
@@ -1,6 +1,0 @@
-elisa-v2.c
-elisa-v2.h
-elisa-v2_types.h
-log_file
-main_syslog
-main_syslog_local

--- a/demos/copilot/src/monitors/Makefile
+++ b/demos/copilot/src/monitors/Makefile
@@ -1,44 +1,51 @@
 # License: SPDX-License-Identifier: MIT
 
+CONTAINER_IMG = registry.gitlab.com/elisa-tech/aero-wg-ci/copilot:latest
+CONTAINER_ARGS = -e HOST_UID="$(shell id -u)" -e HOST_GID="$(shell id -g)" -v $(PWD)/../:/demo
+
 .PHONY: default clean prep run
 
 default: main_syslog main_syslog_local main_syslog_time
 
 prep:
-	cabal update
-	cabal v2-install --lib copilot copilot-core copilot-c99 copilot-language copilot-theorem copilot-libraries copilot-interpreter copilot-prettyprinter
+	docker pull $(CONTAINER_IMG)
+
+dev:
+	docker run -it $(CONTAINER_ARGS) $(CONTAINER_IMG) 
 
 elisa-v2.c elisa-v2.h elisa-v2_types.h: Main.hs Auxiliary.hs
-	runhaskell Main.hs
+	docker run --rm $(CONTAINER_ARGS) $(CONTAINER_IMG) sh -c "cd /demo/monitors && /opt/ghc/8.6.5/bin/runhaskell Main.hs"
 
 elisa-time.c elisa-time.h elisa-time_types.h: MainSyslogClock.hs Auxiliary.hs
-	runhaskell MainSyslogClock.hs
+	docker run --rm $(CONTAINER_ARGS) $(CONTAINER_IMG) sh -c "cd /demo/monitors && /opt/ghc/8.6.5/bin/runhaskell MainSyslogClock.hs"
 
 main_syslog: main_syslog.c elisa-v2.c elisa-v2.h elisa-v2_types.h
-	gcc main_syslog.c elisa-v2.c -o $@
+	docker run --rm $(CONTAINER_ARGS) $(CONTAINER_IMG) sh -c "cd /demo/monitors && gcc main_syslog.c elisa-v2.c -o $@"
 
 main_syslog_local: main_syslog.c elisa-v2.c elisa-v2.h elisa-v2_types.h
-	gcc -DLOG_PATH='"log_file"' -DNOTAIL main_syslog.c elisa-v2.c -o $@
+	docker run --rm $(CONTAINER_ARGS) $(CONTAINER_IMG) sh -c "cd /demo/monitors && gcc -DLOG_PATH='\"log_file\"' -DNOTAIL main_syslog.c elisa-v2.c -o $@"
 
 main_syslog_time: main_syslog_time.c elisa-time.c elisa-time.h elisa-time_types.h
-	gcc -DLOG_PATH='"syslog_file"' -DNOTAIL main_syslog_time.c elisa-time.c -o $@
+	docker run --rm $(CONTAINER_ARGS) $(CONTAINER_IMG) sh -c "cd /demo/monitors && gcc -DLOG_PATH='\"syslog_file\"' -DNOTAIL main_syslog_time.c elisa-time.c -o $@"
 
 clean:
 	rm -f main_syslog main_syslog_local elisa-v2.c elisa-v2.h elisa-v2_types.h elisa-time.*
 
 run: main_syslog_local
 	# Start a new tmux session
-	tmux new-session -d -s my_session
-
 	# Split the window into 3 panes
-	tmux split-window -h
-	tmux split-window -v
-
 	# Run commands in each pane
-	tmux send-keys -t my_session:0.1 "python3 ../python/lightServer.py" C-m
-	sleep 1
-	tmux send-keys -t my_session:0.0 "bash -i <<< './main_syslog_local ; exec </dev/tty'" C-m
-	tmux send-keys -t my_session:0.2 "python3 ../python/switch.py"
-
 	# Attach to the tmux session
-	tmux attach-session -t my_session
+	docker run --rm -it $(CONTAINER_ARGS) $(CONTAINER_IMG) sh -c "cd /demo/monitors \
+		&& touch log_file syslog_file \
+		&& export TERM=xterm-256color \
+		&& tmux new-session -d -s my_session \
+		&& tmux split-window -h \
+		&& tmux split-window -v \
+		&& tmux send-keys -t my_session:0.1 \"python3 ../python/lightServer.py\" C-m \
+		&& sleep 1 \
+		&& tmux send-keys -t my_session:0.0 \"bash -i <<< './main_syslog_local ; exec </dev/tty'\" C-m \
+		&& tmux send-keys -t my_session:0.2 \"python3 ../python/switch.py\" \
+		&& tmux attach-session -t my_session"
+	# To kill session, `Ctrl-b` then type `:kill-session` <enter>
+


### PR DESCRIPTION
- Env setup points user to basic demo to try out env
- Basic demo calls makefile targets and describes tmux run config (credit Martin's PR26
- Makefile fronts all tool calls to use prebuilt container