### PR TITLE
Add another tmux window to tail the log and change app config to log to syslog_file

### DIFF
--- a/demos/copilot/src/monitors/Makefile
+++ b/demos/copilot/src/monitors/Makefile
@@ -42,10 +42,13 @@ run: main_syslog_local
 		&& tmux new-session -d -s my_session \
 		&& tmux split-window -h \
 		&& tmux split-window -v \
-		&& tmux send-keys -t my_session:0.1 \"python3 ../python/lightServer.py\" C-m \
+		&& tmux select-pane -L \
+		&& tmux split-window -v \
+		&& tmux send-keys -t my_session:0.1 \"tail -f syslog_file\" C-m \
+		&& tmux send-keys -t my_session:0.2 \"python3 ../python/lightServer.py\" C-m \
 		&& sleep 1 \
 		&& tmux send-keys -t my_session:0.0 \"bash -i <<< './main_syslog_local ; exec </dev/tty'\" C-m \
-		&& tmux send-keys -t my_session:0.2 \"python3 ../python/switch.py\" \
+		&& tmux send-keys -t my_session:0.3 \"python3 ../python/switch.py\" \
 		&& tmux attach-session -t my_session"
 	# To kill session, `Ctrl-b` then type `:kill-session` <enter>
 

--- a/demos/copilot/src/python/appConfiguration.py
+++ b/demos/copilot/src/python/appConfiguration.py
@@ -15,7 +15,7 @@ class LoggingConfiguration:
     SYSLOG_LOGGING_ENABLED = False
     SYSLOG_FILE_PATH = '/dev/log'
     LOG_FILE_LOGGING_ENABLED = True
-    APP_LOG_FILE = 'log_file'
+    APP_LOG_FILE = 'syslog_file'
     CONSOLE_LOGGING_ENABLED = False
 
 


### PR DESCRIPTION
With the console logging now disabled, there isn't any way for the user to see the logs when running the demo. So I added another tmux window to tail the log so the the user can see the logs while the demo is running.
Also updated the python apps configuration to log to syslog_file instead of log_file