### PR TITLE
Fix timing issues and coordination between light server and monitoring system

### DIFF
--- a/demos/copilot/src/monitors/MainSyslogClock.hs
+++ b/demos/copilot/src/monitors/MainSyslogClock.hs
@@ -43,23 +43,24 @@ switchTurnedOff = risingEdge switchOff
 --
 -- EC: the light switch turns on and, for 500 ms, the lights remain off.
 --
--- EC (refined): If the lights are off, the switch was turned on 500 ms ago
--- and the lights have been off for more than that time.
+-- EC (refined): If the lights are either still off or just turned on, the
+-- switch is on, and it was turned on more than 500 ms ago.
 monitor1 :: Stream Bool
-monitor1 = lightsOff
+monitor1 = (lightsOff || lightsTurnedOn)
         && switchOn
         && timeSinceLastTime' switchTurnedOn > limit
-        && timeSinceLastTime' lightsTurnedOn > limit
 
 -- | SR2: The Cabin Lights system shall turn lights off in less than 500 ms of
 --        the light switch turning off.
 --
 -- EC: the light switch turns off and, for 500 ms, the lights remain on.
+--
+-- EC (refined): If the lights are either still on or just turned off, the
+-- switch is off, and it was turned off more than 500 ms ago.
 monitor2 :: Stream Bool
-monitor2 = lightsOn
+monitor2 = (lightsOn || lightsTurnedOff)
         && switchOff
         && timeSinceLastTime' switchTurnedOff > limit
-        && timeSinceLastTime' lightsTurnedOff > limit
 
 -- | Constant limit: amount of steps betwen the light switch turning on and
 -- the light turning on.

--- a/demos/copilot/src/monitors/Makefile
+++ b/demos/copilot/src/monitors/Makefile
@@ -26,7 +26,7 @@ main_syslog_local: main_syslog.c elisa-v2.c elisa-v2.h elisa-v2_types.h
 	docker run --rm $(CONTAINER_ARGS) $(CONTAINER_IMG) sh -c "cd /demo/monitors && gcc -DLOG_PATH='\"log_file\"' -DNOTAIL main_syslog.c elisa-v2.c -o $@"
 
 main_syslog_time: main_syslog_time.c elisa-time.c elisa-time.h elisa-time_types.h
-	docker run --rm $(CONTAINER_ARGS) $(CONTAINER_IMG) sh -c "cd /demo/monitors && gcc -DLOG_PATH='\"syslog_file\"' -DNOTAIL main_syslog_time.c elisa-time.c -o $@"
+	docker run --rm $(CONTAINER_ARGS) $(CONTAINER_IMG) sh -c "cd /demo/monitors && gcc -DLOG_PATH='\"syslog_file\"' main_syslog_time.c elisa-time.c -o $@"
 
 clean:
 	rm -f main_syslog main_syslog_local main_syslog_time elisa-v2.c elisa-v2.h elisa-v2_types.h elisa-time.*

--- a/demos/copilot/src/monitors/main_syslog_time.c
+++ b/demos/copilot/src/monitors/main_syslog_time.c
@@ -107,7 +107,7 @@ int main() {
             if (strstr(text, SWITCH_OFF_STRING) != NULL)
                lightSwitch = false;
             if (sscanf(text, "[%lf]", &lineTime) == 1) {
-               update_time((int64_t)(lineTime));
+               update_time((int64_t)(lineTime*1000));
             } else {
                gettimeofday(&tv, NULL);
                milliseconds = (int64_t)(tv.tv_sec) * 1000 +

--- a/demos/copilot/src/monitors/main_syslog_time.c
+++ b/demos/copilot/src/monitors/main_syslog_time.c
@@ -28,11 +28,6 @@
 #define SWITCH_OFF_STRING "switch: off"
 
 /*
- * Minimum time delta between events.
- */
-const int64_t MIN_DELTA = 1;
-
-/*
  * Clock used by the monitors.
  */
 int64_t external_clock = 0;
@@ -69,8 +64,6 @@ void violation2 () {
 void update_time(int64_t new_time) {
   if (new_time > external_clock) {
     external_clock = new_time;
-  } else {
-    external_clock += MIN_DELTA;
   }
 }
 
@@ -108,12 +101,11 @@ int main() {
                lightSwitch = false;
             if (sscanf(text, "[%lf]", &lineTime) == 1) {
                update_time((int64_t)(lineTime*1000));
-            } else {
-               gettimeofday(&tv, NULL);
-               milliseconds = (int64_t)(tv.tv_sec) * 1000 +
-                              (int64_t)(tv.tv_usec) / 1000;
-               update_time(milliseconds);
             }
+
+            // Re-evaluate monitors only when new data is received.
+            step();
+
 #ifndef NOTAIL
         } else {
           sleep (1);
@@ -121,8 +113,6 @@ int main() {
 #endif
         }
 
-        // Re-evaluate the monitors
-        step();
     }
 
     // Close the syslog for reading and writing. Presumably, this is never


### PR DESCRIPTION
This commit addresses a timing issue related to time discretization, fixes the translation of time from the syslog (in seconds) to the monitors (in ms), makes the monitors run only when new data is received, and fixes an issue in the coordination between the light server and monitoring driver.