### PR TITLE
Remove references to sample app in lights, light switch demo apps

### DIFF
--- a/demos/copilot/src/cfs/apps/lights_app/config/default_lights_app_fcncodes.h
+++ b/demos/copilot/src/cfs/apps/lights_app/config/default_lights_app_fcncodes.h
@@ -35,7 +35,7 @@
  ************************************************************************/
 
 /*
-** Sample App command codes
+** Lights App command codes
 */
 #define LIGHTS_APP_NOOP_CC           0
 #define LIGHTS_APP_RESET_COUNTERS_CC 1

--- a/demos/copilot/src/cfs/apps/lights_app/config/default_lights_app_msgdefs.h
+++ b/demos/copilot/src/cfs/apps/lights_app/config/default_lights_app_msgdefs.h
@@ -40,7 +40,7 @@ typedef struct LIGHTS_APP_DisplayParam_Payload
 
 /*************************************************************************/
 /*
-** Type definition (Sample App housekeeping)
+** Type definition (Lights App housekeeping)
 */
 
 typedef struct LIGHTS_APP_HkTlm_Payload

--- a/demos/copilot/src/cfs/apps/lights_app/config/default_lights_app_msgstruct.h
+++ b/demos/copilot/src/cfs/apps/lights_app/config/default_lights_app_msgstruct.h
@@ -70,7 +70,7 @@ typedef struct
 
 /*************************************************************************/
 /*
-** Type definition (Sample App housekeeping)
+** Type definition (Lights App housekeeping)
 */
 
 typedef struct

--- a/demos/copilot/src/cfs/apps/lights_app/eds/lights_app.xml
+++ b/demos/copilot/src/cfs/apps/lights_app/eds/lights_app.xml
@@ -30,7 +30,7 @@
 
 -->
 <PackageFile xmlns="http://www.ccsds.org/schema/sois/seds">
-  <Package name="LIGHTS_APP" shortDescription="Sample Application Package">
+  <Package name="LIGHTS_APP" shortDescription="Lights Application Package">
 
     <DataTypeSet>
 
@@ -44,7 +44,7 @@
         </EntryList>
       </ContainerDataType>
 
-      <ContainerDataType name="HkTlm_Payload" shortDescription="Sample App Housekeeping Content">
+      <ContainerDataType name="HkTlm_Payload" shortDescription="Lights App Housekeeping Content">
         <EntryList>
           <Entry name="CommandCounter" type="BASE_TYPES/uint8" />
           <Entry name="CommandErrorCounter" type="BASE_TYPES/uint8" />

--- a/demos/copilot/src/cfs/apps/lights_app/fsw/inc/lights_app_eventids.h
+++ b/demos/copilot/src/cfs/apps/lights_app/fsw/inc/lights_app_eventids.h
@@ -21,7 +21,7 @@
 /**
  * @file
  *
- * Define Sample App Events IDs
+ * Define Lights App Events IDs
  */
 
 #ifndef LIGHTS_APP_EVENTS_H

--- a/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app.c
+++ b/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app.c
@@ -92,7 +92,7 @@ void LIGHTS_APP_Main(void)
         else
         {
             CFE_EVS_SendEvent(LIGHTS_APP_PIPE_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "SAMPLE APP: SB Pipe Read Error, App Will Exit");
+                              "LIGHTS APP: SB Pipe Read Error, App Will Exit");
 
             LIGHTS_APP_Data.RunStatus = CFE_ES_RunStatus_APP_ERROR;
         }

--- a/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_cmds.c
+++ b/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_cmds.c
@@ -20,7 +20,7 @@
 
 /**
  * \file
- *   This file contains the source code for the Sample App Ground Command-handling functions
+ *   This file contains the source code for the Lights App Ground Command-handling functions
  */
 
 /*
@@ -75,14 +75,14 @@ CFE_Status_t LIGHTS_APP_SendHkCmd(const LIGHTS_APP_SendHkCmd_t *Msg)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 /*                                                                            */
-/* SAMPLE NOOP commands                                                       */
+/* LIGHTS NOOP commands                                                       */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 CFE_Status_t LIGHTS_APP_NoopCmd(const LIGHTS_APP_NoopCmd_t *Msg)
 {
     LIGHTS_APP_Data.CmdCounter++;
 
-    CFE_EVS_SendEvent(LIGHTS_APP_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE: NOOP command %s",
+    CFE_EVS_SendEvent(LIGHTS_APP_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "LIGHTS: NOOP command %s",
                       LIGHTS_APP_VERSION);
 
     return CFE_SUCCESS;
@@ -100,7 +100,7 @@ CFE_Status_t LIGHTS_APP_ResetCountersCmd(const LIGHTS_APP_ResetCountersCmd_t *Ms
     LIGHTS_APP_Data.CmdCounter = 0;
     LIGHTS_APP_Data.ErrCounter = 0;
 
-    CFE_EVS_SendEvent(LIGHTS_APP_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE: RESET command");
+    CFE_EVS_SendEvent(LIGHTS_APP_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "LIGHTS: RESET command");
 
     return CFE_SUCCESS;
 }
@@ -118,24 +118,24 @@ CFE_Status_t LIGHTS_APP_ProcessCmd(const LIGHTS_APP_ProcessCmd_t *Msg)
     LIGHTS_APP_ExampleTable_t *TblPtr;
     const char *               TableName = "LIGHTS_APP.ExampleTable";
 
-    /* Sample Use of Example Table */
+    /* Lights Use of Example Table */
     LIGHTS_APP_Data.CmdCounter++;
     Status = CFE_TBL_GetAddress(&TblAddr, LIGHTS_APP_Data.TblHandles[0]);
     if (Status < CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("Sample App: Fail to get table address: 0x%08lx", (unsigned long)Status);
+        CFE_ES_WriteToSysLog("Lights App: Fail to get table address: 0x%08lx", (unsigned long)Status);
     }
     else
     {
         TblPtr = TblAddr;
-        CFE_ES_WriteToSysLog("Sample App: Example Table Value 1: %d  Value 2: %d", TblPtr->Int1, TblPtr->Int2);
+        CFE_ES_WriteToSysLog("Lights App: Example Table Value 1: %d  Value 2: %d", TblPtr->Int1, TblPtr->Int2);
 
         LIGHTS_APP_GetCrc(TableName);
 
         Status = CFE_TBL_ReleaseAddress(LIGHTS_APP_Data.TblHandles[0]);
         if (Status != CFE_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("Sample App: Fail to release table address: 0x%08lx", (unsigned long)Status);
+            CFE_ES_WriteToSysLog("Lights App: Fail to release table address: 0x%08lx", (unsigned long)Status);
         }
         else
         {

--- a/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_cmds.h
+++ b/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_cmds.h
@@ -20,7 +20,7 @@
 
 /**
  * @file
- *   This file contains the prototypes for the Sample App Ground Command-handling functions
+ *   This file contains the prototypes for the Lights App Ground Command-handling functions
  */
 
 #ifndef LIGHTS_APP_CMDS_H

--- a/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_dispatch.c
+++ b/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_dispatch.c
@@ -20,7 +20,7 @@
 
 /**
  * \file
- *   This file contains the source code for the Sample App.
+ *   This file contains the source code for the Lights App.
  */
 
 /*
@@ -76,7 +76,7 @@ bool LIGHTS_APP_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t Expected
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 /*                                                                            */
-/* SAMPLE ground commands                                                     */
+/* LIGHTS ground commands                                                     */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 void LIGHTS_APP_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr)
@@ -86,7 +86,7 @@ void LIGHTS_APP_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr)
     CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &CommandCode);
 
     /*
-    ** Process SAMPLE app ground commands
+    ** Process LIGHTS app ground commands
     */
     switch (CommandCode)
     {
@@ -129,7 +129,7 @@ void LIGHTS_APP_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 /*                                                                            */
 /*  Purpose:                                                                  */
-/*     This routine will process any packet that is received on the SAMPLE    */
+/*     This routine will process any packet that is received on the LIGHTS    */
 /*     command pipe.                                                          */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
@@ -159,7 +159,7 @@ void LIGHTS_APP_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
 
         default:
             CFE_EVS_SendEvent(LIGHTS_APP_MID_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "SAMPLE: invalid command packet,MID = 0x%x", (unsigned int)CFE_SB_MsgIdToValue(MsgId));
+                              "LIGHTS: invalid command packet,MID = 0x%x", (unsigned int)CFE_SB_MsgIdToValue(MsgId));
             break;
     }
 }

--- a/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_dispatch.h
+++ b/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_dispatch.h
@@ -21,7 +21,7 @@
 /**
  * @file
  *
- * Main header file for the SAMPLE application
+ * Main header file for the LIGHTS application
  */
 
 #ifndef LIGHTS_APP_DISPATCH_H

--- a/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_eds_dispatch.c
+++ b/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_eds_dispatch.c
@@ -20,7 +20,7 @@
 
 /**
  * \file
- *   This file contains the source code for the Sample App.
+ *   This file contains the source code for the Lights App.
  */
 
 /*
@@ -37,9 +37,9 @@
 #include "lights_app_eds_dictionary.h"
 
 /*
- * Define a lookup table for SAMPLE app command codes
+ * Define a lookup table for LIGHTS app command codes
  */
-static const EdsDispatchTable_LIGHTS_APP_Application_CFE_SB_Telecommand_t SAMPLE_TC_DISPATCH_TABLE = {
+static const EdsDispatchTable_LIGHTS_APP_Application_CFE_SB_Telecommand_t LIGHTS_TC_DISPATCH_TABLE = {
     .CMD     = {.NoopCmd_indication          = LIGHTS_APP_NoopCmd,
             .ResetCountersCmd_indication = LIGHTS_APP_ResetCountersCmd,
             .ProcessCmd_indication       = LIGHTS_APP_ProcessCmd,
@@ -49,7 +49,7 @@ static const EdsDispatchTable_LIGHTS_APP_Application_CFE_SB_Telecommand_t SAMPLE
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 /*                                                                            */
 /*  Purpose:                                                                  */
-/*     This routine will process any packet that is received on the SAMPLE    */
+/*     This routine will process any packet that is received on the LIGHTS    */
 /*     command pipe.                                                          */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
@@ -60,7 +60,7 @@ void LIGHTS_APP_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
     CFE_MSG_Size_t    MsgSize;
     CFE_MSG_FcnCode_t MsgFc;
 
-    Status = EdsDispatch_LIGHTS_APP_Application_Telecommand(SBBufPtr, &SAMPLE_TC_DISPATCH_TABLE);
+    Status = EdsDispatch_LIGHTS_APP_Application_Telecommand(SBBufPtr, &LIGHTS_TC_DISPATCH_TABLE);
 
     if (Status != CFE_SUCCESS)
     {
@@ -72,7 +72,7 @@ void LIGHTS_APP_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         if (Status == CFE_STATUS_UNKNOWN_MSG_ID)
         {
             CFE_EVS_SendEvent(LIGHTS_APP_MID_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "SAMPLE: invalid command packet,MID = 0x%x", (unsigned int)CFE_SB_MsgIdToValue(MsgId));
+                              "LIGHTS: invalid command packet,MID = 0x%x", (unsigned int)CFE_SB_MsgIdToValue(MsgId));
         }
         else if (Status == CFE_STATUS_WRONG_MSG_LENGTH)
         {
@@ -83,7 +83,7 @@ void LIGHTS_APP_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         else
         {
             CFE_EVS_SendEvent(LIGHTS_APP_CC_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "SAMPLE: Invalid ground command code: CC = %d", (int)MsgFc);
+                              "LIGHTS: Invalid ground command code: CC = %d", (int)MsgFc);
         }
     }
 }

--- a/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_utils.c
+++ b/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_utils.c
@@ -20,7 +20,7 @@
 
 /**
  * \file
- *   This file contains the source code for the Sample App utility functions
+ *   This file contains the source code for the Lights App utility functions
  */
 
 /*
@@ -42,7 +42,7 @@ CFE_Status_t LIGHTS_APP_TblValidationFunc(void *TblData)
     LIGHTS_APP_ExampleTable_t *TblDataPtr = (LIGHTS_APP_ExampleTable_t *)TblData;
 
     /*
-    ** Sample Example Table Validation
+    ** Lights Example Table Validation
     */
     if (TblDataPtr->Int1 > LIGHTS_APP_TBL_ELEMENT_1_MAX)
     {
@@ -67,11 +67,11 @@ void LIGHTS_APP_GetCrc(const char *TableName)
     status = CFE_TBL_GetInfo(&TblInfoPtr, TableName);
     if (status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("Sample App: Error Getting Example Table Info");
+        CFE_ES_WriteToSysLog("Lights App: Error Getting Example Table Info");
     }
     else
     {
         Crc = TblInfoPtr.Crc;
-        CFE_ES_WriteToSysLog("Sample App: CRC: 0x%08lX\n\n", (unsigned long)Crc);
+        CFE_ES_WriteToSysLog("Lights App: CRC: 0x%08lX\n\n", (unsigned long)Crc);
     }
 }

--- a/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_utils.h
+++ b/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_utils.h
@@ -20,7 +20,7 @@
 
 /**
  * @file
- *   This file contains the prototypes for the Sample App utility functions
+ *   This file contains the prototypes for the Lights App utility functions
  */
 
 #ifndef LIGHTS_APP_UTILS_H

--- a/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_version.h
+++ b/demos/copilot/src/cfs/apps/lights_app/fsw/src/lights_app_version.h
@@ -21,7 +21,7 @@
 /**
  * @file
  *
- *  The Sample App header file containing version information
+ *  The Lights App header file containing version information
  */
 
 #ifndef LIGHTS_APP_VERSION_H

--- a/demos/copilot/src/cfs/apps/lights_app/unit-test/common/eventcheck.c
+++ b/demos/copilot/src/cfs/apps/lights_app/unit-test/common/eventcheck.c
@@ -22,11 +22,11 @@
 ** File: coveragetest_lights_app.c
 **
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the LIGHTS Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the LIGHTS application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/lights_app/unit-test/common/eventcheck.h
+++ b/demos/copilot/src/cfs/apps/lights_app/unit-test/common/eventcheck.h
@@ -20,11 +20,11 @@
 
 /*
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the LIGHTS Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the LIGHTS application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/lights_app/unit-test/common/setup.c
+++ b/demos/copilot/src/cfs/apps/lights_app/unit-test/common/setup.c
@@ -20,11 +20,11 @@
 
 /*
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the LIGHTS Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the LIGHTS application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/lights_app/unit-test/common/setup.h
+++ b/demos/copilot/src/cfs/apps/lights_app/unit-test/common/setup.h
@@ -20,11 +20,11 @@
 
 /*
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the LIGHTS Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the LIGHTS application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/lights_app/unit-test/coveragetest/coveragetest_lights_app.c
+++ b/demos/copilot/src/cfs/apps/lights_app/unit-test/coveragetest/coveragetest_lights_app.c
@@ -22,11 +22,11 @@
 ** File: coveragetest_lights_app.c
 **
 ** Purpose:
-** Coverage Unit Test cases for the Sample Application
+** Coverage Unit Test cases for the Lights Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the Sample application.
+** paths through all functions defined in the Lights application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that
@@ -128,7 +128,7 @@ void Test_LIGHTS_APP_Main(void)
      */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RunLoop), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_ReceiveBuffer), 1, CFE_SB_PIPE_RD_ERR);
-    UT_CHECKEVENT_SETUP(&EventTest, LIGHTS_APP_PIPE_ERR_EID, "SAMPLE APP: SB Pipe Read Error, App Will Exit");
+    UT_CHECKEVENT_SETUP(&EventTest, LIGHTS_APP_PIPE_ERR_EID, "LIGHTS APP: SB Pipe Read Error, App Will Exit");
 
     /*
      * Invoke again

--- a/demos/copilot/src/cfs/apps/lights_app/unit-test/coveragetest/coveragetest_lights_app_cmds.c
+++ b/demos/copilot/src/cfs/apps/lights_app/unit-test/coveragetest/coveragetest_lights_app_cmds.c
@@ -22,11 +22,11 @@
 ** File: coveragetest_lights_app.c
 **
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the LIGHTS Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the LIGHTS application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that
@@ -115,7 +115,7 @@ void Test_LIGHTS_APP_ResetCountersCmd(void)
 
     memset(&TestMsg, 0, sizeof(TestMsg));
 
-    UT_CHECKEVENT_SETUP(&EventTest, LIGHTS_APP_RESET_INF_EID, "SAMPLE: RESET command");
+    UT_CHECKEVENT_SETUP(&EventTest, LIGHTS_APP_RESET_INF_EID, "LIGHTS: RESET command");
 
     UtAssert_INT32_EQ(LIGHTS_APP_ResetCountersCmd(&TestMsg), CFE_SUCCESS);
 

--- a/demos/copilot/src/cfs/apps/lights_app/unit-test/coveragetest/coveragetest_lights_app_dispatch.c
+++ b/demos/copilot/src/cfs/apps/lights_app/unit-test/coveragetest/coveragetest_lights_app_dispatch.c
@@ -20,11 +20,11 @@
 
 /*
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the LIGHTS Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the LIGHTS application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that
@@ -65,7 +65,7 @@ void Test_LIGHTS_APP_TaskPipe(void)
     UT_CheckEvent_t   EventTest;
 
     memset(&TestMsg, 0, sizeof(TestMsg));
-    UT_CHECKEVENT_SETUP(&EventTest, LIGHTS_APP_MID_ERR_EID, "SAMPLE: invalid command packet,MID = 0x%x");
+    UT_CHECKEVENT_SETUP(&EventTest, LIGHTS_APP_MID_ERR_EID, "LIGHTS: invalid command packet,MID = 0x%x");
 
     /*
      * The CFE_MSG_GetMsgId() stub uses a data buffer to hold the

--- a/demos/copilot/src/cfs/apps/lights_app/unit-test/coveragetest/coveragetest_lights_app_eds_dispatch.c
+++ b/demos/copilot/src/cfs/apps/lights_app/unit-test/coveragetest/coveragetest_lights_app_eds_dispatch.c
@@ -20,11 +20,11 @@
 
 /*
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the LIGHTS Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the LIGHTS application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/lights_app/unit-test/coveragetest/coveragetest_lights_app_utils.c
+++ b/demos/copilot/src/cfs/apps/lights_app/unit-test/coveragetest/coveragetest_lights_app_utils.c
@@ -22,11 +22,11 @@
 ** File: coveragetest_lights_app.c
 **
 ** Purpose:
-** Coverage Unit Test cases for the Sample Application
+** Coverage Unit Test cases for the Lights Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the Sample application.
+** paths through all functions defined in the Lights application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/switch_app/config/default_switch_app_fcncodes.h
+++ b/demos/copilot/src/cfs/apps/switch_app/config/default_switch_app_fcncodes.h
@@ -35,7 +35,7 @@
  ************************************************************************/
 
 /*
-** Sample App command codes
+** Switch App command codes
 */
 #define SWITCH_APP_NOOP_CC           0
 #define SWITCH_APP_RESET_COUNTERS_CC 1

--- a/demos/copilot/src/cfs/apps/switch_app/config/default_switch_app_msgdefs.h
+++ b/demos/copilot/src/cfs/apps/switch_app/config/default_switch_app_msgdefs.h
@@ -40,7 +40,7 @@ typedef struct SWITCH_APP_DisplayParam_Payload
 
 /*************************************************************************/
 /*
-** Type definition (Sample App housekeeping)
+** Type definition (Switch App housekeeping)
 */
 
 typedef struct SWITCH_APP_HkTlm_Payload

--- a/demos/copilot/src/cfs/apps/switch_app/config/default_switch_app_msgstruct.h
+++ b/demos/copilot/src/cfs/apps/switch_app/config/default_switch_app_msgstruct.h
@@ -70,7 +70,7 @@ typedef struct
 
 /*************************************************************************/
 /*
-** Type definition (Sample App housekeeping)
+** Type definition (Switch App housekeeping)
 */
 
 typedef struct

--- a/demos/copilot/src/cfs/apps/switch_app/eds/switch_app.xml
+++ b/demos/copilot/src/cfs/apps/switch_app/eds/switch_app.xml
@@ -30,7 +30,7 @@
 
 -->
 <PackageFile xmlns="http://www.ccsds.org/schema/sois/seds">
-  <Package name="SWITCH_APP" shortDescription="Sample Application Package">
+  <Package name="SWITCH_APP" shortDescription="Switch Application Package">
 
     <DataTypeSet>
 
@@ -44,7 +44,7 @@
         </EntryList>
       </ContainerDataType>
 
-      <ContainerDataType name="HkTlm_Payload" shortDescription="Sample App Housekeeping Content">
+      <ContainerDataType name="HkTlm_Payload" shortDescription="Switch App Housekeeping Content">
         <EntryList>
           <Entry name="CommandCounter" type="BASE_TYPES/uint8" />
           <Entry name="CommandErrorCounter" type="BASE_TYPES/uint8" />

--- a/demos/copilot/src/cfs/apps/switch_app/fsw/inc/switch_app_eventids.h
+++ b/demos/copilot/src/cfs/apps/switch_app/fsw/inc/switch_app_eventids.h
@@ -21,7 +21,7 @@
 /**
  * @file
  *
- * Define Sample App Events IDs
+ * Define Switch App Events IDs
  */
 
 #ifndef SWITCH_APP_EVENTS_H

--- a/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app.c
+++ b/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app.c
@@ -92,7 +92,7 @@ void SWITCH_APP_Main(void)
         else
         {
             CFE_EVS_SendEvent(SWITCH_APP_PIPE_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "SAMPLE APP: SB Pipe Read Error, App Will Exit");
+                              "SWITCH APP: SB Pipe Read Error, App Will Exit");
 
             SWITCH_APP_Data.RunStatus = CFE_ES_RunStatus_APP_ERROR;
         }

--- a/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_cmds.c
+++ b/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_cmds.c
@@ -20,7 +20,7 @@
 
 /**
  * \file
- *   This file contains the source code for the Sample App Ground Command-handling functions
+ *   This file contains the source code for the Switch App Ground Command-handling functions
  */
 
 /*
@@ -75,14 +75,14 @@ CFE_Status_t SWITCH_APP_SendHkCmd(const SWITCH_APP_SendHkCmd_t *Msg)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 /*                                                                            */
-/* SAMPLE NOOP commands                                                       */
+/* SWITCH NOOP commands                                                       */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 CFE_Status_t SWITCH_APP_NoopCmd(const SWITCH_APP_NoopCmd_t *Msg)
 {
     SWITCH_APP_Data.CmdCounter++;
 
-    CFE_EVS_SendEvent(SWITCH_APP_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE: NOOP command %s",
+    CFE_EVS_SendEvent(SWITCH_APP_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "SWITCH: NOOP command %s",
                       SWITCH_APP_VERSION);
 
     return CFE_SUCCESS;
@@ -100,7 +100,7 @@ CFE_Status_t SWITCH_APP_ResetCountersCmd(const SWITCH_APP_ResetCountersCmd_t *Ms
     SWITCH_APP_Data.CmdCounter = 0;
     SWITCH_APP_Data.ErrCounter = 0;
 
-    CFE_EVS_SendEvent(SWITCH_APP_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "SAMPLE: RESET command");
+    CFE_EVS_SendEvent(SWITCH_APP_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "SWITCH: RESET command");
 
     return CFE_SUCCESS;
 }
@@ -118,24 +118,24 @@ CFE_Status_t SWITCH_APP_ProcessCmd(const SWITCH_APP_ProcessCmd_t *Msg)
     SWITCH_APP_ExampleTable_t *TblPtr;
     const char *               TableName = "SWITCH_APP.ExampleTable";
 
-    /* Sample Use of Example Table */
+    /* Switch Use of Example Table */
     SWITCH_APP_Data.CmdCounter++;
     Status = CFE_TBL_GetAddress(&TblAddr, SWITCH_APP_Data.TblHandles[0]);
     if (Status < CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("Sample App: Fail to get table address: 0x%08lx", (unsigned long)Status);
+        CFE_ES_WriteToSysLog("Switch App: Fail to get table address: 0x%08lx", (unsigned long)Status);
     }
     else
     {
         TblPtr = TblAddr;
-        CFE_ES_WriteToSysLog("Sample App: Example Table Value 1: %d  Value 2: %d", TblPtr->Int1, TblPtr->Int2);
+        CFE_ES_WriteToSysLog("Switch App: Example Table Value 1: %d  Value 2: %d", TblPtr->Int1, TblPtr->Int2);
 
         SWITCH_APP_GetCrc(TableName);
 
         Status = CFE_TBL_ReleaseAddress(SWITCH_APP_Data.TblHandles[0]);
         if (Status != CFE_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("Sample App: Fail to release table address: 0x%08lx", (unsigned long)Status);
+            CFE_ES_WriteToSysLog("Switch App: Fail to release table address: 0x%08lx", (unsigned long)Status);
         }
         else
         {

--- a/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_cmds.h
+++ b/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_cmds.h
@@ -20,7 +20,7 @@
 
 /**
  * @file
- *   This file contains the prototypes for the Sample App Ground Command-handling functions
+ *   This file contains the prototypes for the Switch App Ground Command-handling functions
  */
 
 #ifndef SWITCH_APP_CMDS_H

--- a/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_dispatch.c
+++ b/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_dispatch.c
@@ -20,7 +20,7 @@
 
 /**
  * \file
- *   This file contains the source code for the Sample App.
+ *   This file contains the source code for the Switch App.
  */
 
 /*
@@ -74,7 +74,7 @@ bool SWITCH_APP_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t Expected
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 /*                                                                            */
-/* SAMPLE ground commands                                                     */
+/* SWITCH ground commands                                                     */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 void SWITCH_APP_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr)
@@ -84,7 +84,7 @@ void SWITCH_APP_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr)
     CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &CommandCode);
 
     /*
-    ** Process SAMPLE app ground commands
+    ** Process SWITCH app ground commands
     */
     switch (CommandCode)
     {
@@ -127,7 +127,7 @@ void SWITCH_APP_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 /*                                                                            */
 /*  Purpose:                                                                  */
-/*     This routine will process any packet that is received on the SAMPLE    */
+/*     This routine will process any packet that is received on the SWITCH    */
 /*     command pipe.                                                          */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
@@ -153,7 +153,7 @@ void SWITCH_APP_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
 
         default:
             CFE_EVS_SendEvent(SWITCH_APP_MID_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "SAMPLE: invalid command packet,MID = 0x%x", (unsigned int)CFE_SB_MsgIdToValue(MsgId));
+                              "SWITCH: invalid command packet,MID = 0x%x", (unsigned int)CFE_SB_MsgIdToValue(MsgId));
             break;
     }
 }

--- a/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_dispatch.h
+++ b/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_dispatch.h
@@ -21,7 +21,7 @@
 /**
  * @file
  *
- * Main header file for the SAMPLE application
+ * Main header file for the SWITCH application
  */
 
 #ifndef SWITCH_APP_DISPATCH_H

--- a/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_eds_dispatch.c
+++ b/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_eds_dispatch.c
@@ -20,7 +20,7 @@
 
 /**
  * \file
- *   This file contains the source code for the Sample App.
+ *   This file contains the source code for the Switch App.
  */
 
 /*
@@ -37,9 +37,9 @@
 #include "switch_app_eds_dictionary.h"
 
 /*
- * Define a lookup table for SAMPLE app command codes
+ * Define a lookup table for SWITCH app command codes
  */
-static const EdsDispatchTable_SWITCH_APP_Application_CFE_SB_Telecommand_t SAMPLE_TC_DISPATCH_TABLE = {
+static const EdsDispatchTable_SWITCH_APP_Application_CFE_SB_Telecommand_t SWITCH_TC_DISPATCH_TABLE = {
     .CMD     = {.NoopCmd_indication          = SWITCH_APP_NoopCmd,
             .ResetCountersCmd_indication = SWITCH_APP_ResetCountersCmd,
             .ProcessCmd_indication       = SWITCH_APP_ProcessCmd,
@@ -49,7 +49,7 @@ static const EdsDispatchTable_SWITCH_APP_Application_CFE_SB_Telecommand_t SAMPLE
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 /*                                                                            */
 /*  Purpose:                                                                  */
-/*     This routine will process any packet that is received on the SAMPLE    */
+/*     This routine will process any packet that is received on the SWITCH    */
 /*     command pipe.                                                          */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
@@ -60,7 +60,7 @@ void SWITCH_APP_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
     CFE_MSG_Size_t    MsgSize;
     CFE_MSG_FcnCode_t MsgFc;
 
-    Status = EdsDispatch_SWITCH_APP_Application_Telecommand(SBBufPtr, &SAMPLE_TC_DISPATCH_TABLE);
+    Status = EdsDispatch_SWITCH_APP_Application_Telecommand(SBBufPtr, &SWITCH_TC_DISPATCH_TABLE);
 
     if (Status != CFE_SUCCESS)
     {
@@ -72,7 +72,7 @@ void SWITCH_APP_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         if (Status == CFE_STATUS_UNKNOWN_MSG_ID)
         {
             CFE_EVS_SendEvent(SWITCH_APP_MID_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "SAMPLE: invalid command packet,MID = 0x%x", (unsigned int)CFE_SB_MsgIdToValue(MsgId));
+                              "SWITCH: invalid command packet,MID = 0x%x", (unsigned int)CFE_SB_MsgIdToValue(MsgId));
         }
         else if (Status == CFE_STATUS_WRONG_MSG_LENGTH)
         {
@@ -83,7 +83,7 @@ void SWITCH_APP_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         else
         {
             CFE_EVS_SendEvent(SWITCH_APP_CC_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "SAMPLE: Invalid ground command code: CC = %d", (int)MsgFc);
+                              "SWITCH: Invalid ground command code: CC = %d", (int)MsgFc);
         }
     }
 }

--- a/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_utils.c
+++ b/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_utils.c
@@ -20,7 +20,7 @@
 
 /**
  * \file
- *   This file contains the source code for the Sample App utility functions
+ *   This file contains the source code for the Switch App utility functions
  */
 
 /*
@@ -42,7 +42,7 @@ CFE_Status_t SWITCH_APP_TblValidationFunc(void *TblData)
     SWITCH_APP_ExampleTable_t *TblDataPtr = (SWITCH_APP_ExampleTable_t *)TblData;
 
     /*
-    ** Sample Example Table Validation
+    ** Switch Example Table Validation
     */
     if (TblDataPtr->Int1 > SWITCH_APP_TBL_ELEMENT_1_MAX)
     {
@@ -67,11 +67,11 @@ void SWITCH_APP_GetCrc(const char *TableName)
     status = CFE_TBL_GetInfo(&TblInfoPtr, TableName);
     if (status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("Sample App: Error Getting Example Table Info");
+        CFE_ES_WriteToSysLog("Switch App: Error Getting Example Table Info");
     }
     else
     {
         Crc = TblInfoPtr.Crc;
-        CFE_ES_WriteToSysLog("Sample App: CRC: 0x%08lX\n\n", (unsigned long)Crc);
+        CFE_ES_WriteToSysLog("Switch App: CRC: 0x%08lX\n\n", (unsigned long)Crc);
     }
 }

--- a/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_utils.h
+++ b/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_utils.h
@@ -20,7 +20,7 @@
 
 /**
  * @file
- *   This file contains the prototypes for the Sample App utility functions
+ *   This file contains the prototypes for the Switch App utility functions
  */
 
 #ifndef SWITCH_APP_UTILS_H

--- a/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_version.h
+++ b/demos/copilot/src/cfs/apps/switch_app/fsw/src/switch_app_version.h
@@ -21,7 +21,7 @@
 /**
  * @file
  *
- *  The Sample App header file containing version information
+ *  The Switch App header file containing version information
  */
 
 #ifndef SWITCH_APP_VERSION_H

--- a/demos/copilot/src/cfs/apps/switch_app/unit-test/common/eventcheck.c
+++ b/demos/copilot/src/cfs/apps/switch_app/unit-test/common/eventcheck.c
@@ -22,11 +22,11 @@
 ** File: coveragetest_switch_app.c
 **
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the SWITCH Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the SWITCH application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/switch_app/unit-test/common/eventcheck.h
+++ b/demos/copilot/src/cfs/apps/switch_app/unit-test/common/eventcheck.h
@@ -20,11 +20,11 @@
 
 /*
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the SWITCH Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the SWITCH application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/switch_app/unit-test/common/setup.c
+++ b/demos/copilot/src/cfs/apps/switch_app/unit-test/common/setup.c
@@ -20,11 +20,11 @@
 
 /*
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the SWITCH Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the SWITCH application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/switch_app/unit-test/common/setup.h
+++ b/demos/copilot/src/cfs/apps/switch_app/unit-test/common/setup.h
@@ -20,11 +20,11 @@
 
 /*
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the SWITCH Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the SWITCH application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/switch_app/unit-test/coveragetest/coveragetest_switch_app.c
+++ b/demos/copilot/src/cfs/apps/switch_app/unit-test/coveragetest/coveragetest_switch_app.c
@@ -22,11 +22,11 @@
 ** File: coveragetest_switch_app.c
 **
 ** Purpose:
-** Coverage Unit Test cases for the Sample Application
+** Coverage Unit Test cases for the Switch Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the Sample application.
+** paths through all functions defined in the Switch application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that
@@ -128,7 +128,7 @@ void Test_SWITCH_APP_Main(void)
      */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RunLoop), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_ReceiveBuffer), 1, CFE_SB_PIPE_RD_ERR);
-    UT_CHECKEVENT_SETUP(&EventTest, SWITCH_APP_PIPE_ERR_EID, "SAMPLE APP: SB Pipe Read Error, App Will Exit");
+    UT_CHECKEVENT_SETUP(&EventTest, SWITCH_APP_PIPE_ERR_EID, "SWITCH APP: SB Pipe Read Error, App Will Exit");
 
     /*
      * Invoke again

--- a/demos/copilot/src/cfs/apps/switch_app/unit-test/coveragetest/coveragetest_switch_app_cmds.c
+++ b/demos/copilot/src/cfs/apps/switch_app/unit-test/coveragetest/coveragetest_switch_app_cmds.c
@@ -22,11 +22,11 @@
 ** File: coveragetest_switch_app.c
 **
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the SWITCH Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the SWITCH application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that
@@ -115,7 +115,7 @@ void Test_SWITCH_APP_ResetCountersCmd(void)
 
     memset(&TestMsg, 0, sizeof(TestMsg));
 
-    UT_CHECKEVENT_SETUP(&EventTest, SWITCH_APP_RESET_INF_EID, "SAMPLE: RESET command");
+    UT_CHECKEVENT_SETUP(&EventTest, SWITCH_APP_RESET_INF_EID, "SWITCH: RESET command");
 
     UtAssert_INT32_EQ(SWITCH_APP_ResetCountersCmd(&TestMsg), CFE_SUCCESS);
 

--- a/demos/copilot/src/cfs/apps/switch_app/unit-test/coveragetest/coveragetest_switch_app_dispatch.c
+++ b/demos/copilot/src/cfs/apps/switch_app/unit-test/coveragetest/coveragetest_switch_app_dispatch.c
@@ -20,11 +20,11 @@
 
 /*
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the SWITCH Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the SWITCH application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that
@@ -65,7 +65,7 @@ void Test_SWITCH_APP_TaskPipe(void)
     UT_CheckEvent_t   EventTest;
 
     memset(&TestMsg, 0, sizeof(TestMsg));
-    UT_CHECKEVENT_SETUP(&EventTest, SWITCH_APP_MID_ERR_EID, "SAMPLE: invalid command packet,MID = 0x%x");
+    UT_CHECKEVENT_SETUP(&EventTest, SWITCH_APP_MID_ERR_EID, "SWITCH: invalid command packet,MID = 0x%x");
 
     /*
      * The CFE_MSG_GetMsgId() stub uses a data buffer to hold the

--- a/demos/copilot/src/cfs/apps/switch_app/unit-test/coveragetest/coveragetest_switch_app_eds_dispatch.c
+++ b/demos/copilot/src/cfs/apps/switch_app/unit-test/coveragetest/coveragetest_switch_app_eds_dispatch.c
@@ -20,11 +20,11 @@
 
 /*
 ** Purpose:
-** Coverage Unit Test cases for the SAMPLE Application
+** Coverage Unit Test cases for the SWITCH Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the SAMPLE application.
+** paths through all functions defined in the SWITCH application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that

--- a/demos/copilot/src/cfs/apps/switch_app/unit-test/coveragetest/coveragetest_switch_app_utils.c
+++ b/demos/copilot/src/cfs/apps/switch_app/unit-test/coveragetest/coveragetest_switch_app_utils.c
@@ -22,11 +22,11 @@
 ** File: coveragetest_switch_app.c
 **
 ** Purpose:
-** Coverage Unit Test cases for the Sample Application
+** Coverage Unit Test cases for the Switch Application
 **
 ** Notes:
 ** This implements various test cases to exercise all code
-** paths through all functions defined in the Sample application.
+** paths through all functions defined in the Switch application.
 **
 ** It is primarily focused at providing examples of the various
 ** stub configurations, hook functions, and wrapper calls that


### PR DESCRIPTION
Remove references to the sample app in the lights and light switch cFS demonstration apps.

Fixes #241.